### PR TITLE
style: render SolverForge ASCII banner in emerald green

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@
 # Rust build system with colorized output
 
 # ============== Colors & Symbols ==============
-GREEN := \033[92m
+GREEN := \033[38;2;16;185;129m
 CYAN := \033[96m
 YELLOW := \033[93m
 MAGENTA := \033[95m


### PR DESCRIPTION
### Motivation
- User-visible ASCII banner should use Tailwind-like emerald green, so update the terminal color used for all `SolverForge` ASCII art.

### Description
- Replace the `GREEN` ANSI color in the `Makefile` from `\033[92m` to the truecolor code `\033[38;2;16;185;129m` so the banner prints in emerald green and existing `$(GREEN)` tokens remain in-place.

### Testing
- Ran `make banner` to verify the banner renders with the updated emerald tone and the command completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cfdae4bcf48331b3ecf27f506fb075)